### PR TITLE
imageFormat param in serve ad

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,5 @@
 import { APIError, AuthenticationError, ValidationError } from "./error";
-import type { SpecifyAd, SpecifyInitConfig } from "./types";
+import type { SpecifyAd, SpecifyInitConfig, ImageFormat } from "./types";
 
 type Address = `0x${string}`;
 
@@ -52,10 +52,11 @@ export default class Specify {
    * Serves content to the specified wallet address
    *
    * @param address - Ethereum or EVM-compatible wallet address
+   * @param imageFormat - Image format to serve
    * @throws {ValidationError} When wallet address format is invalid
    * @returns Ad content for the specified wallet address or null if the ad is not found
    */
-  public async serve(address: Address): Promise<SpecifyAd | null> {
+  public async serve(address: Address, imageFormat: ImageFormat): Promise<SpecifyAd | null> {
     if (!this.validateAddress(address)) {
       throw new ValidationError("Invalid wallet address");
     }
@@ -68,7 +69,7 @@ export default class Specify {
           "Content-Type": "application/json",
           "x-api-key": this.publisherKey,
         },
-        body: JSON.stringify({ walletAddress: address }),
+        body: JSON.stringify({ walletAddress: address, imageFormat }),
       });
 
       if (!response.ok) {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2,6 +2,14 @@ export interface SpecifyInitConfig {
   publisherKey: string;
 }
 
+export enum ImageFormat {
+  LANDSCAPE = "LANDSCAPE",
+  SQUARE = "SQUARE",
+  LONG_BANNER = "LONG_BANNER",
+  SHORT_BANNER = "SHORT_BANNER",
+  NO_IMAGE = "NO_IMAGE",
+}
+
 export interface SpecifyAd {
   walletAddress: string;
   campaignId: string;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@specify-sh/sdk",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "description": "JS SDK for Specify Publishers",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Linear issue: https://linear.app/ticc-co/issue/TICC-655/add-ad-unit-id-parameter-to-sdk-serve-function
Related PR: https://app.graphite.dev/github/pr/InternetCommunityCompany/specify/630/TICC-648---AdImage-schema